### PR TITLE
Fix task name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@ module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    testacularServer: {
+    testacular: {
       unit: {
         configFile: "testacular.conf.js"
       }
@@ -16,6 +16,6 @@ module.exports = function(grunt) {
   grunt.loadTasks('tasks');
 
   // Default task.
-  grunt.registerTask('default', 'testacularServer');
-  grunt.registerTask('test', 'testacularServer');
+  grunt.registerTask('default', 'testacular');
+  grunt.registerTask('test', 'testacular');
 };


### PR DESCRIPTION
Hi,
The task has been renamed in `grunt-testacular@0.3.0`, so `testacularServer` doesn't work. In `grunt-testacular@0.3.0` use `testacular` instead.